### PR TITLE
Specify plot parameters as named list, avoids opening device with no …

### DIFF
--- a/config/R_config.R
+++ b/config/R_config.R
@@ -52,9 +52,8 @@ if (map_projection!="no") {
 
 
 # Custom paramteres for plots
-zero<-par(mfrow=panels,cex.main=2.5,cex.axis=1.5,cex.lab=1.5,mar=c(5,5,5,7),oma=c(1,1,3,2))
-plotpar<-par(no.readonly=T)
-dev.off()
+plotpar=list(mfrow = panels, cex.main = 2.5, cex.axis = 1.5, cex.lab = 1.5,
+            mar = c(5, 5, 5, 7), oma = c(1, 1, 3, 2))
 
 # imagescale3 color bar details
 imgscl_colorbar=1.4


### PR DESCRIPTION
Currently custom plot parameters are generated in `R_config.R` by calling `par()` and then obtaining from it `plotpar` as a named list using `par(no.readonly = FALSE)`.
The problem is that this opens the current device (pdf by default) even if no `pdf()` command has ever been called, and no filename has been specified. As a result a fake `Rplot.pdf` file is generated in the current working directory. 
Also, later a different type of figure (png, pdf or eps) may be opened in `open.plot.device` but in theory the plot parameters obtained from `par(no.readonly = FALSE)` can only be used exactly for the same device (see https://stat.ethz.ch/R-manual/R-devel/library/graphics/html/par.html )
This fix solves the problem by constructing explicitly the plotpar named list.